### PR TITLE
Extend scriptability patch 1

### DIFF
--- a/autoload/OmniSharp/actions/definition.vim
+++ b/autoload/OmniSharp/actions/definition.vim
@@ -78,7 +78,8 @@ function! s:CBGotoDefinition(opts, location, metadata) abort
       let found = 0
     endif
   else
-    let found = OmniSharp#locations#Navigate(a:location, a:opts.editcommand)
+    let loc = OmniSharp#util#TranslatePathForClient(a:location)
+    let found = OmniSharp#locations#Navigate(loc, a:opts.editcommand)
   endif
   if has_key(a:opts, 'Callback') && !went_to_metadata
     call a:opts.Callback(found)
@@ -96,7 +97,8 @@ function! s:CBPreviewDefinition(opts, location, metadata) abort
       echo 'Not found'
     endif
   else
-    call OmniSharp#locations#Preview(a:location)
+    let loc = OmniSharp#util#TranslatePathForClient(a:location)
+    call OmniSharp#locations#Preview(loc)
     echo fnamemodify(a:location.filename, ':.')
   endif
 endfunction

--- a/autoload/OmniSharp/actions/implementations.vim
+++ b/autoload/OmniSharp/actions/implementations.vim
@@ -49,9 +49,11 @@ function! s:CBFindImplementations(target, opts, locations) abort
   if numImplementations == 0
     echo 'No implementations found'
   elseif numImplementations == 1
-    call OmniSharp#locations#Navigate(a:locations[0])
+    let loc = OmniSharp#util#TranslatePathForClient(a:locations[0])
+    call OmniSharp#locations#Navigate(loc)
   else " numImplementations > 1
-    call OmniSharp#locations#SetQuickfix(a:locations,
+    let locations = OmniSharp#util#TranslateLocationsForClient(a:locations)
+    call OmniSharp#locations#SetQuickfix(locations,
     \ 'Implementations: ' . a:target)
   endif
   if has_key(a:opts, 'Callback')
@@ -65,8 +67,9 @@ function! s:CBPreviewImplementation(locs, ...) abort
     if numImplementations == 0
       echo 'No implementations found'
     else
-      call OmniSharp#locations#Preview(a:locs[0])
-      let fname = fnamemodify(a:locs[0].filename, ':.')
+      let loc = OmniSharp#util#TranslatePathForClient(a:locs[0])
+      call OmniSharp#locations#Preview(loc)
+      let fname = fnamemodify(loc.filename, ':.')
       if numImplementations == 1
         echo fname
       else

--- a/autoload/OmniSharp/actions/symbols.vim
+++ b/autoload/OmniSharp/actions/symbols.vim
@@ -33,18 +33,20 @@ function! s:CBFindSymbol(filter, locations) abort
     echo 'No symbols found'
     return
   endif
+
+  let locations = OmniSharp#util#TranslateLocationsForClient(a:locations)
   if g:OmniSharp_selector_ui ==? 'clap'
-    call clap#OmniSharp#FindSymbols(a:locations)
+    call clap#OmniSharp#FindSymbols(locations)
   elseif g:OmniSharp_selector_ui ==? 'unite'
-    call unite#start([['OmniSharp/findsymbols', a:locations]])
+    call unite#start([['OmniSharp/findsymbols', locations]])
   elseif g:OmniSharp_selector_ui ==? 'ctrlp'
-    call ctrlp#OmniSharp#findsymbols#setsymbols(a:locations)
+    call ctrlp#OmniSharp#findsymbols#setsymbols(locations)
     call ctrlp#init(ctrlp#OmniSharp#findsymbols#id())
   elseif g:OmniSharp_selector_ui ==? 'fzf'
-    call fzf#OmniSharp#FindSymbols(a:locations)
+    call fzf#OmniSharp#FindSymbols(locations)
   else
     let title = 'Symbols' . (len(a:filter) ? ': ' . a:filter : '')
-    call OmniSharp#locations#SetQuickfix(a:locations, title)
+    call OmniSharp#locations#SetQuickfix(locations, title)
   endif
 endfunction
 

--- a/autoload/OmniSharp/actions/usages.vim
+++ b/autoload/OmniSharp/actions/usages.vim
@@ -47,12 +47,16 @@ function! s:CBFindUsages(target, locations) abort
   let numUsages = len(a:locations)
   if numUsages == 0
     echo 'No usages found'
-  elseif get(g:, 'OmniSharp_selector_findusages', '') ==? 'fzf'
-    call fzf#OmniSharp#FindUsages(a:locations, a:target)
+    return 0
+  endif
+
+  let locations = OmniSharp#util#TranslateLocationsForClient(a:locations)
+  if get(g:, 'OmniSharp_selector_findusages', '') ==? 'fzf'
+    call fzf#OmniSharp#FindUsages(locations, a:target)
   elseif get(g:, 'OmniSharp_selector_findusages', '') ==? 'clap'
-    call clap#OmniSharp#FindUsages(a:locations, a:target)
+    call clap#OmniSharp#FindUsages(locations, a:target)
   else
-    call OmniSharp#locations#SetQuickfix(a:locations, 'Usages: ' . a:target)
+    call OmniSharp#locations#SetQuickfix(locations, 'Usages: ' . a:target)
   endif
   return numUsages
 endfunction

--- a/autoload/OmniSharp/actions/usings.vim
+++ b/autoload/OmniSharp/actions/usings.vim
@@ -46,7 +46,8 @@ endfunction
 function! s:CBFixUsings(opts, locations) abort
   let numAmbiguous = len(a:locations)
   if numAmbiguous > 0
-    call OmniSharp#locations#SetQuickfix(a:locations, 'Ambiguous usings')
+    let locations = OmniSharp#util#TranslateLocationsForClient(a:locations)
+    call OmniSharp#locations#SetQuickfix(locations, 'Ambiguous usings')
   endif
   if has_key(a:opts, 'Callback')
     call a:opts.Callback(numAmbiguous)

--- a/autoload/OmniSharp/locations.vim
+++ b/autoload/OmniSharp/locations.vim
@@ -57,7 +57,7 @@ function! OmniSharp#locations#Parse(quickfixes) abort
   for quickfix in a:quickfixes
     let location = {
     \ 'filename': has_key(quickfix, 'FileName')
-    \   ? OmniSharp#util#TranslatePathForClient(quickfix.FileName)
+    \   ? quickfix.FileName
     \   : expand('%:p'),
     \ 'text': get(quickfix, 'Text', get(quickfix, 'Message', '')),
     \ 'lnum': quickfix.Line,

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -300,6 +300,16 @@ function! OmniSharp#util#TranslatePathForClient(filename) abort
   return fnamemodify(filename, modifiers)
 endfunction
 
+function! OmniSharp#util#TranslateLocationsForClient(locations) abort
+  let fixedLocations = []
+  for location in a:locations
+    let fixedLocation = location
+    let fixedLocation.filename = OmniSharp#util#TranslatePathForClient(location.filename)
+    call add(fixedLocations, fixedLocation)
+  endfor
+  return fixedLocations
+endfunction
+
 function! OmniSharp#util#TranslatePathForServer(filename) abort
   let filename = a:filename
   if g:OmniSharp_translate_cygwin_wsl && (s:is_wsl() || s:is_msys() || s:is_cygwin())


### PR DESCRIPTION
Here's what I promised on https://github.com/OmniSharp/omnisharp-vim/pull/680 (yeah PR to PR is complicated).

The next step would be to move all these util calls into `location#Preview`, `#Navigate`, `#SetQuickFix` and the various quick fix alternatives. But I wanted first to see if this is the direction that you meant.

The next-next step could be to do a similar refactor of the other actions which have a callback and currently pass it the location count in addition to displaying (instead of passing the locations themselves, instead of displaying) - i.e. `implementations.vim` and `usings.vim`.